### PR TITLE
Add gitmux link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-spotify-info](https://github.com/jdxcode/tmux-spotify-info) Spotify track info on your status bar
 - [tmux-weather](https://github.com/jdxcode/tmux-weather) Add weather status via forcast.io
 - [tmux-weather](https://github.com/xamut/tmux-weather) Show current weather using wttr.in
+- [gitmux](https://github.com/arl/gitmux) Show Git status in tmux status bar
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 
 ## Status Bar
 
+- [gitmux](https://github.com/arl/gitmux) Show Git status in tmux status bar
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) Plug and play battery percentage and icon indicator for Tmux.
 - [tmux-cpu](https://github.com/tmux-plugins/tmux-cpu) Show CPU load with easy icons
 - [tmux-cpu-info](https://github.com/jdxcode/tmux-cpu-info) CPU usage guage to status bar
@@ -71,7 +72,6 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-spotify-info](https://github.com/jdxcode/tmux-spotify-info) Spotify track info on your status bar
 - [tmux-weather](https://github.com/jdxcode/tmux-weather) Add weather status via forcast.io
 - [tmux-weather](https://github.com/xamut/tmux-weather) Show current weather using wttr.in
-- [gitmux](https://github.com/arl/gitmux) Show Git status in tmux status bar
 
 ## Plugins
 


### PR DESCRIPTION
First, thanks for doing that awesome list!
I'm the author and maintainer of https://github.com/arl/gitmux. Gitmux shows Git status in tmux status bar, it's a rewrite from scratch of https://github.com/arl/tmux-gitbar, which I also wrote.
Gitmux is shell-indepedent and some binaries for many platforms are pre-compiled and available as Github releases.
It's very stable and used everyday by many persons already, it has few stars since I published it like recently.
I believe gitmux is a good match with this list ;-) 