### PR TITLE
Fixed a typo in the description of vim-tmux-navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmuxomatic](https://github.com/oxidane/tmuxomatic) Intelligent tmux session management
 - [tmuxp](https://github.com/tony/tmuxp) :computer: tmux session manager and python library
 - [tmuxpair](https://github.com/goerz/tmuxpair) Command line script for setting up a temporary tmux session for pair programming
-- [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) Vim and tmux intigration
+- [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) Vim and tmux integration
 
 ## Themes
 


### PR DESCRIPTION
See title, I fixed a small typo in the document.