### PR TITLE
Add the tmux-wormhole plugin to the plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-spotify](https://github.com/xamut/tmux-spotify) Show a nice menu to manage Spotify application
 - [tmux-urlscan](https://github.com/fszymanski/tmux-urlscan) Open any URL on your terminal window
 - [tmux-tilish](https://github.com/jabirali/tmux-tilish) Turn tmux into a dynamic window manager with intuitive keybindings (inspired by i3wm/sway)
+- [tmux-wormhole](https://github.com/gcla/tmux-wormhole) Use tmux to download files with magic wormhole
 - [tmux-plugins](https://github.com/tmux-plugins) Official tmux plugins
   - [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) Continuous saving of tmux environment. Automatic restore when tmux is started. Automatic tmux start when computer is turned on.
   - [tmux-copycat](https://github.com/tmux-plugins/tmux-copycat) A plugin that enhances tmux search


### PR DESCRIPTION
I published this yesterday on github. It's a tmux plugin that scrapes
the active tmux pane for a magic wormhole code, then downloads and
optionally opens the file tied to the code. I wrote this to make it
easier to get pcaps from termshark into Wireshark.