### PR TITLE
add tmux-df

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-colortag](https://github.com/Determinant/tmux-colortag) a plugin/theme that colors the tmux window tags.
 - [tmux-cpu-info](https://github.com/jdxcode/tmux-cpu-info) CPU usage gauge to status bar
 - [tmux-cpu](https://github.com/tmux-plugins/tmux-cpu) Show CPU load with easy icons
+- [tmux-df](https://github.com/tassaron/tmux-df) - Show available disk space (output of df command)
 - [tmux-kripto](https://github.com/vascomfnunes/tmux-kripto) Add a cryptocurrency stock price to the statusbar.
 - [tmux-maildir-counter](https://github.com/tmux-plugins/tmux-maildir-counter) Plugin that counts files on a specific mail directory
 - [tmux-mem-cpu-load](https://github.com/thewtex/tmux-mem-cpu-load) CPU, RAM memory, and load monitor for use with tmux


### PR DESCRIPTION
I made this simple plugin that adds some interpolation strings to show the output of `df -h` in the statusbar. It's not much but I'm using it every day so I'll definitely maintain it. Currently it's not configurable so it always shows `/` mountpoint but I'll definitely add some config eventually for that.