### PR TITLE
Add tmux-open-nvim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-modal](https://github.com/whame/tmux-modal) - Execute complex tmux commands in just a few keystrokes with a modal mode that is designed to be efficient, easy to remember and comfortable.
 - [tmux-mouse-swipe](https://github.com/jaclu/tmux-mouse-swipe) - Switch Window or Session by clicking right mouse button and swiping.
 - [tmux-notify](https://github.com/ChanderG/tmux-notify) A plugin to notify you when processes complete.
+- [tmux-open-nvim](https://github.com/trevarj/tmux-open-nvim) - A plugin to help open files in a running instance of Neovim. Pairs well with tmux-fingers or tmux-open.
 - [tmux-thumbs](https://github.com/fcsonline/tmux-thumbs) A lightning fast version of tmux-fingers written in Rust, copy/pasting tmux like vimium/vimperator
 - [tmux-1password](https://github.com/yardnsm/tmux-1password) Access your 1Password login items in a tmux pane.
 - [tmux-jump](https://github.com/schasse/tmux-jump) Vimium/Easymotion like navigation for tmux.


### PR DESCRIPTION
tmux-open-nvim is a plugin that finds an instance of neovim running in the current tmux window and opens a file there. It integrates well with tmux-fingers or tmux-open for when a file path is in a pane and you want to open that file in neovim in an adjacent pane.