### PR TITLE
Add tmux-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmex](https://github.com/evnp/tmex) A minimalist tmux layout manager
 - [tmux-cssh](https://github.com/zinic/tmux-cssh) Tmux with a "ClusterSSH"-like behavior
 - [tmux-conf](https://github.com/jaclu/tmux-conf) Meant for users running tmux on multiple hosts, not always running the same version. Generates tmux config files using version checks
+- [tmux-project](https://github.com/sei40kr/tmux-project) Search projects and open them in a new session
 - [tmux-suspend](https://github.com/MunifTanjim/tmux-suspend) Suspend local session for painlessly working with nested remote session.
 - [tmux-up](https://github.com/jamesottaway/tmux-up) Bootstrap new `tmux` sessions without complex tools, DSLs, or dependencies
 - [tmuxake](https://github.com/nkh/tmuxake) A side-pane manager for tmux


### PR DESCRIPTION
tmux-project is a plugin that searches for projects and opens them in a new session. It is inspired by [tmuxinator](https://github.com/tmuxinator/tmuxinator), but it aims zero-configuration.