### PR TITLE
docs: migrate tmux-notify to new upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-menus](https://github.com/jaclu/tmux-menus) - Popup menus to help with managing your environment.
 - [tmux-modal](https://github.com/whame/tmux-modal) - Execute complex tmux commands in just a few keystrokes with a modal mode that is designed to be efficient, easy to remember and comfortable.
 - [tmux-mouse-swipe](https://github.com/jaclu/tmux-mouse-swipe) - Switch Window or Session by clicking right mouse button and swiping.
-- [tmux-notify](https://github.com/ChanderG/tmux-notify) A plugin to notify you when processes complete.
+- [tmux-notify](https://github.com/rickstaa/tmux-notify) A plugin to notify you when processes complete.
 - [tmux-open-nvim](https://github.com/trevarj/tmux-open-nvim) - A plugin to help open files in a running instance of Neovim. Pairs well with tmux-fingers or tmux-open.
 - [tmux-thumbs](https://github.com/fcsonline/tmux-thumbs) A lightning fast version of tmux-fingers written in Rust, copy/pasting tmux like vimium/vimperator
 - [tmux-1password](https://github.com/yardnsm/tmux-1password) Access your 1Password login items in a tmux pane.


### PR DESCRIPTION
The original tmux-notify upstream is no longer maintained (see https://github.com/ChanderG/tmux-notify/issues/38). This pull request updates it to the new maintained upstream.
