### PR TITLE
Add tmux-fzf-open-files-nvim plugin to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-mouse-swipe](https://github.com/jaclu/tmux-mouse-swipe) - Switch Window or Session by clicking right mouse button and swiping.
 - [tmux-notify](https://github.com/rickstaa/tmux-notify) A plugin to notify you when processes are finished.
 - [tmux-open-nvim](https://github.com/trevarj/tmux-open-nvim) - A plugin to help open files in a running instance of Neovim. Pairs well with tmux-fingers or tmux-open.
+- [tmux-fzf-open-files-nvim](https://github.com/Peter-McKinney/tmux-fzf-open-files-nvim) - A plugin that parses pane text for files for selection in fzf to open in neovim.
 - [tmux-thumbs](https://github.com/fcsonline/tmux-thumbs) A lightning fast version of tmux-fingers written in Rust, copy/pasting tmux like vimium/vimperator
 - [tmux-1password](https://github.com/yardnsm/tmux-1password) Access your 1Password login items in a tmux pane.
 - [tmux-jump](https://github.com/schasse/tmux-jump) Vimium/Easymotion like navigation for tmux.


### PR DESCRIPTION
Add [tmux-fzf-open-files-nvim](https://github.com/Peter-McKinney/tmux-fzf-open-files-nvim) plugin which parses pane output for filenames and opens them in neovim. This plugin will open files in new tabs in a running neovim instance if a pane is found to be running neovim in the current window, otherwise it will create a new horizontal tmux pane.

Users can search the current pane's visible output.
Users can search the current pane's entire history.
Users can search all pane's in a window and their entire history. 


https://github.com/user-attachments/assets/dd261d45-b66e-438f-961c-3f624b812a23


https://github.com/user-attachments/assets/cecb6143-11f8-4e49-9151-2160e830fd34


https://github.com/user-attachments/assets/6d191600-b2eb-4fa2-ae86-067aca6f57d5


https://github.com/user-attachments/assets/868d3406-f00b-4954-828c-4922105c7708

