### PR TITLE
Add mooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 ## Configuration
 
 - [Oh My Tmux!](https://github.com/gpakosz/.tmux) Powerline-like theme, vim bindings, SSH aware, improved maximize pane, ...
-- [mooks](https://github.com/TomhetArkitektur/mooks) A minimal tmux configuration framework designed for well-structured modular setups
 - [Example tmux config](https://github.com/tony/tmux-config) :green_book: Example tmux configuration - screen + vim key-bindings, system stat, cpu load bar
 - [Guide to customizing tmux.conf](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/)
+- [mooks](https://github.com/TomhetArkitektur/mooks) A minimal tmux configuration framework designed for well-structured modular setups
 - [practical tmux](https://mutelight.org/practical-tmux)
 - [tmux-extra](https://github.com/brandur/tmux-extra) Configuration and scripts for sane Tmux default behavior
 - [tmux-keybtest](https://github.com/jaclu/tmux-keybtest) Check what keys tmux can detect from the terminal being used.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 ## Configuration
 
 - [Oh My Tmux!](https://github.com/gpakosz/.tmux) Powerline-like theme, vim bindings, SSH aware, improved maximize pane, ...
+- [mooks](https://github.com/TomhetArkitektur/mooks) A minimal tmux configuration framework designed for well-structured modular setups
 - [Example tmux config](https://github.com/tony/tmux-config) :green_book: Example tmux configuration - screen + vim key-bindings, system stat, cpu load bar
 - [Guide to customizing tmux.conf](https://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/)
 - [practical tmux](https://mutelight.org/practical-tmux)


### PR DESCRIPTION
Add mooks - a minimal tmux configuration framework designed for well-structured modular setups