### PR TITLE
Fixes broken article link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 
 - [Automatically start tmux on SSH](http://marklodato.github.io/2013/10/31/autostart-tmux-on-ssh.html)
 - [Tmux crash course](https://thoughtbot.com/blog/a-tmux-crash-course)
-- [Tmux and Vim together](https://www.bugsnag.com/blog/tmux-and-vim)
+- [Tmux and Vim together](https://smartbear.com/blog/tmux-and-vim/)
 
 ## <a name="cheatsheets"></a>Cheat Sheets
 


### PR DESCRIPTION
"Tmux and Vim together" article link is broken after the migration of bugsnag.com to smartbear.com