### PR TITLE
Add tmux-compile to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-browser](https://github.com/ofirgall/tmux-browser) Web browser sessions attached to tmux sessions.
 - [tmux-cht-sh](https://github.com/kenos1/tmux-cht-sh) Access cheatsheets easily in a popup
 - [tmux-click-copy](https://github.com/aless3/tmux-click-copy) word/line copy on double/triple click without fixed timeout and without remaining stuck in copy mode
+- [tmux-compile](https://github.com/alexekdahl/tmux-compile) Run compile commands directly inside tmux with automatic pane handling.
 - [tmux-command-palette](https://github.com/lost-melody/tmux-command-palette) Search for keybindings and custom commands with fzf.
 - [tmux-copytk](https://github.com/CrispyConductor/tmux-copy-toolkit) - Multi utility rapid copy toolkit.
 - [tmux-devcontainers](https://github.com/phil/tmux-devcontainers) - Manage and interact with (Devcontainers)[https://containers.dev]


### PR DESCRIPTION
This PR adds tmux-compile to the Plugins section.

tmux-compile is a plugin that makes it easy to compile code directly inside tmux.
It automatically opens a split pane for compilation output, reuses it on subsequent runs, and keeps the workflow smooth and keyboard-driven.

Repo: https://github.com/alexekdahl/tmux-compile

The entry is added in alphabetical order and follows the formatting of the existing list.