### PR TITLE
Add ccb to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 ## <a name="tools"></a>Tools and session management
 
 - [automux](https://github.com/sriramkandukuri/automux) Wrappers to tmux commands, useful for tmux based automation
+- [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.


### PR DESCRIPTION
Hello! 👋

I'd like to submit **ccb** (Claude Code Bridge) to the list.

It's a CLI tool that integrates multiple LLMs (Claude, Gemini, OpenAI, etc.) directly into tmux panes, enabling collaborative workflows between different AI assistants.

**Why it belongs here:**
- **Tmux-native:** Designed specifically for tmux, managing AI agents in separate panes
- **Popularity:** 900+ stars on GitHub
- **Utility:** Enables cross-agent communication and orchestration within tmux sessions

Link: https://github.com/bfly123/claude_code_bridge

Thanks for maintaining this awesome list!