### PR TITLE
Add tmux-speedtest to Status Bar section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-powerline-nostatus](https://gist.github.com/james1236/73bb8b7279dca0bc821518abada38f1e) Display your tmux window list directly in your terminal prompt, eliminating the tmux status bar.
 - [tmux-prefix-highlight](https://github.com/tmux-plugins/tmux-prefix-highlight) Plugin that highlights when you press tmux prefix key
 - [tmux-split-statusbar](https://github.com/charlietag/tmux-split-statusbar) Plugin for splitting status bar into 2 parts - window + left/right status
+- [tmux-speedtest](https://github.com/YousefHadder/tmux-speedtest) Run internet speed tests and display results in your status bar.
 - [tmux-spotify-info](https://github.com/jdxcode/tmux-spotify-info) Spotify track info on your status bar (OSX)
 - [tmux-spotify-info](https://github.com/Feqzz/tmux-spotify-info) Spotify track info on your status bar (Linux)
 - [tmux-transient-status](https://github.com/TheSast/tmux-transient-status) Automatically make your tmux status bar vanish when unneded.


### PR DESCRIPTION
## Summary
- Adds [tmux-speedtest](https://github.com/YousefHadder/tmux-speedtest) to the Status Bar section
- Plugin runs internet speed tests and displays download/upload speeds and latency in the tmux status bar
- Non-blocking operation keeps tmux responsive during tests
- Supports multiple speedtest CLI backends (Ookla, fast-cli, speedtest-cli)