### PR TITLE
Add tmux-session-dots to Status Bar section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-pomodoro-plus](https://github.com/olimorris/tmux-pomodoro-plus) Incorporate the Pomodoro technique into your tmux workflow
 - [tmux-powerline-nostatus](https://gist.github.com/james1236/73bb8b7279dca0bc821518abada38f1e) Display your tmux window list directly in your terminal prompt, eliminating the tmux status bar.
 - [tmux-prefix-highlight](https://github.com/tmux-plugins/tmux-prefix-highlight) Plugin that highlights when you press tmux prefix key
+- [tmux-session-dots](https://github.com/jtmcginty/tmux-session-dots) Visual session indicator showing all sessions as dots with the current session highlighted.
 - [tmux-split-statusbar](https://github.com/charlietag/tmux-split-statusbar) Plugin for splitting status bar into 2 parts - window + left/right status
 - [tmux-speedtest](https://github.com/YousefHadder/tmux-speedtest) Run internet speed tests and display results in your status bar.
 - [tmux-spotify-info](https://github.com/jdxcode/tmux-spotify-info) Spotify track info on your status bar (OSX)


### PR DESCRIPTION
Adds tmux-session-dots - a visual session indicator that shows all sessions as dots (●○○) with the current session highlighted.

Useful for users who frequently switch between multiple tmux sessions and want instant visual feedback about which session they're in.
