### PR TITLE
Add tmux-claude-sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-bitwarden](https://github.com/Alkindi42/tmux-bitwarden) Access your Bitwarden login items in a tmux pane.
 - [tmux-browser](https://github.com/ofirgall/tmux-browser) Web browser sessions attached to tmux sessions.
 - [tmux-cht-sh](https://github.com/kenos1/tmux-cht-sh) Access cheatsheets easily in a popup
+- [tmux-claude-sessions](https://github.com/aomerk/tmux-claude-sessions) Browse and resume Claude AI conversations from a fzf popup
 - [tmux-click-copy](https://github.com/aless3/tmux-click-copy) word/line copy on double/triple click without fixed timeout and without remaining stuck in copy mode
 - [tmux-compile](https://github.com/alexekdahl/tmux-compile) Run compile commands directly inside tmux with automatic pane handling.
 - [tmux-command-palette](https://github.com/lost-melody/tmux-command-palette) Search for keybindings and custom commands with fzf.


### PR DESCRIPTION
Browse and resume Claude AI conversations directly from tmux.

- `Prefix+g` opens an fzf popup listing all Claude sessions grouped by project
- Live preview of the conversation on the right
- Select to resume with `claude -r <id>` in a new window
- TPM compatible, configurable, MIT license

https://github.com/aomerk/tmux-claude-sessions