### PR TITLE
Add tabby to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [kmux-status](https://github.com/tardunge/kmux-status) - Tmux plugin to render kubernetes context and other indicators on the status-line.
 - [muxile](https://github.com/bjesus/muxile) - View and control your tmux session from your mobile.
 - [nunchux](https://github.com/datamadsen/nunchux) A fuzzy launcher for apps, files, and build tasks with live status, keyboard shortcuts, and task runner integration.
+- [tabby](https://github.com/brendandebeasi/tabby) Modern tab manager with a daemon-driven vertical sidebar, window grouping, and full mouse support.
 - [tmux-agent-indicator](https://github.com/accessd/tmux-agent-indicator) Track AI agent state (Claude, Codex, etc.) with pane borders, background colors, window titles, and status bar icons.
 - [tmux-autoreload](https://github.com/b0o/tmux-autoreload) - Watches your tmux configuration file and automatically reloads it on change.
 - [tmux-bitwarden](https://github.com/Alkindi42/tmux-bitwarden) Access your Bitwarden login items in a tmux pane.


### PR DESCRIPTION
## Summary

Adding [tabby](https://github.com/brendandebeasi/tabby) to the Plugins section.

Tabby is a tmux plugin that provides a daemon-driven vertical sidebar and optional horizontal tab bar for window and pane management. It features window grouping with color coding, full mouse support (click, scroll, right-click context menus), and deep linking. Built with Go and Bubble Tea.

- Placed alphabetically between `nunchux` and `tmux-agent-indicator`
- Follows existing entry format (`- [name](url) Description.`)