### PR TITLE
Add tmux-manager to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-conf](https://github.com/jaclu/tmux-conf) Meant for users running tmux on multiple hosts, not always running the same version. Generates tmux config files using version checks
 - [tmux-grip](https://github.com/leohenon/tmux-grip) Pin tmux sessions to fixed numbered slots with direct key jumps and a popup manager
 - [tmux-lazy-restore](https://github.com/bcampolo/tmux-lazy-restore) A session manager that allows sessions to be lazily restored in order to save memory and CPU cycles.
+- [tmux-manager](https://github.com/charlie0077/tmux-manager) A TUI for managing tmux sessions across multiple remote servers via SSH, with live session counts and YAML config.
 - [tmux-nav-master](https://github.com/TheSast/tmux-nav-master) Easy cross-navigation between tmux and other terminal applications.
 - [tmux-poltergeist](https://github.com/dianoga-theory/tmux-poltergeist) Clipboard-like popup for injecting up to 10 text buffers
 - [tmux-powerkit](https://github.com/fabioluciano/tmux-powerkit) A tmux framework to create and distribute plugins and themes - Already have 36+ plugins, and 2 themes.


### PR DESCRIPTION
## Summary

- Adds [tmux-manager](https://github.com/charlie0077/tmux-manager) to the **Tools and session management** section (alphabetical order)

## What is tmux-manager?

A TUI for managing tmux sessions across multiple remote servers via SSH. Built with Go + Bubbletea.

**Key features:**
- Browse servers and their tmux session counts in one view
- Attach, create, and kill sessions on any server without leaving the TUI
- Add/remove servers from inside the TUI (persisted to YAML)
- Local tmux supported out of the box
- Ctrl-q to detach and return to the TUI

**Why it's different:** Most tmux session managers focus on local sessions. tmux-manager is specifically designed for managing tmux across multiple remote servers via SSH from a single interface.

Repo: https://github.com/charlie0077/tmux-manager