### PR TITLE
Add crmux - Claude Code session multiplexer in tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 
 - [automux](https://github.com/sriramkandukuri/automux) Wrappers to tmux commands, useful for tmux based automation
 - [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
+- [crmux](https://github.com/maedana/crmux) A session multiplexer for Claude Code in tmux. Monitor multiple sessions from a single sidebar, switch panes, send prompts, and preview output.
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.


### PR DESCRIPTION
crmux is a session multiplexer for Claude Code in tmux. Monitor multiple sessions from a single sidebar, switch panes, send prompts, and preview output.