### PR TITLE
Add kkueinput - CJK IME input helper for tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.
+- [kkueinput](https://github.com/douchekr/kkueinput) A GTK3 floating IME input helper for CJK text composition in tmux sessions. Sends composed text via tmux send-keys, with SSH remote session support.
 - [laio](https://laio.sh) A simple, flexbox-inspired, layout & session manager for tmux written in Rust.
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux
 - [moxide](https://github.com/dlurak/moxide) A tmux session manager with a modular config


### PR DESCRIPTION
## kkueinput

A GTK3 floating IME input helper for CJK text composition in tmux sessions.

**What it does**: Provides a floating input window with full IME support (Korean, Japanese, Chinese), then injects composed text into a target tmux session via `tmux send-keys`. Supports both local and remote (SSH) tmux sessions.

**Why it's useful**: Programs using raw terminal mode (e.g. Claude CLI, Node.js readline) intercept keystrokes before the IME can compose characters. kkueinput solves this by providing an external composition window.

- GitHub: https://github.com/douchekr/kkueinput
- License: MIT
- Category: Tools and session management