### PR TITLE
Add batty — tmux-native AI agent team runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 ## <a name="tools"></a>Tools and session management
 
 - [automux](https://github.com/sriramkandukuri/automux) Wrappers to tmux commands, useful for tmux based automation
+- [batty](https://github.com/battysh/batty) A tmux-native runtime for hierarchical AI coding agent teams, with role-based orchestration, git worktree isolation, and kanban-driven task dispatch
 - [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust


### PR DESCRIPTION
Adds [Batty](https://github.com/battysh/batty) to the Tools and session management section.

Batty is a tmux-native runtime for hierarchical AI coding agent teams. You define roles (architect, manager, engineers) in YAML, and Batty launches them in tmux panes, routes messages between roles, isolates engineer work in git worktrees, and dispatches tasks from a kanban board.

- Written in Rust
- Available on crates.io: `cargo install batty-cli`
- MIT licensed
- Active development with CI, docs site, and demo video