### PR TITLE
Add lazy-tmux — tool for snapshots sessions with scrollback and restores lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 
 ## <a name="tools"></a>Tools and session management
 
+- [lazy-tmux](https://lazy-tmux.xyz) A CLI that snapshots tmux sessions (including running processes and scrollback) and restores them lazily and seamlessly when selected.
 - [automux](https://github.com/sriramkandukuri/automux) Wrappers to tmux commands, useful for tmux based automation
 - [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files


### PR DESCRIPTION
Adds lazy-tmux to the "Tools and Session Management" section.

lazy-tmux is a CLI session manager for tmux that snapshots running sessions, including panes, layouts, commands, and scrollback history, and restores them lazily on demand. 

Key features:
- Save sessions: current, specific, or all, with full environment and scrollback.
- Lazy restore: only load what you need, avoiding high RAM usage.
- Autosave daemon: periodically snapshots all sessions without conflicts.
- Interactive TUI browser and keyboard-driven picker for fast navigation and management.
- Flexible sorting and optional fzf integration for lightweight searching.
- Bootstrap restore: auto-restore latest or specific sessions on tmux startup.

Written in Go
Project architect: [@alchemmist](https://github.com/alchemmist)

Check out [lazy-tmux.xyz](https://lazy-tmux.xyz/?utm_source=github) for installation and usage.

MIT licensed, actively developed with CI, docs, and demos.