### PR TITLE
Add PAD to tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux
 - [moxide](https://github.com/dlurak/moxide) A tmux session manager with a modular config
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management TUI built on tmux
+- [pad](https://github.com/T1mn/pad) A tmux-native control panel for Codex, Claude Code, Gemini CLI, and other terminal agents with session previews, pane jumps, notifications, and launcher support
 - [powerline](https://github.com/powerline/powerline) Statusline plugin for vim, and provides statuslines and prompts for several other applications including tmux
 - [tmux-powerline](https://github.com/erikw/tmux-powerline) A hackable statusbar for tmux consisting of dynamic & beautiful looking segments, inspired by vim-powerline, written purely in bash.
 - [sesh](https://github.com/joshmedeski/sesh) Smart session manager for the terminal


### PR DESCRIPTION
PAD is a tmux-native control panel for managing terminal agent sessions with previews, pane jumps, notifications, and launcher support.\n\nIt fits the tools and session management section as a tmux-focused workflow tool.\n\nProject: https://github.com/T1mn/pad