### PR TITLE
Add Batty

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 ## <a name="tools"></a>Tools and session management
 
 - [automux](https://github.com/sriramkandukuri/automux) Wrappers to tmux commands, useful for tmux based automation
+- [batty](https://github.com/battysh/batty) A supervisor for AI coding agent teams using tmux panes, git worktree isolation, and test-gated task completion
 - [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust


### PR DESCRIPTION
[Batty](https://github.com/battysh/batty) is a supervisor for AI coding agent teams that uses tmux as the runtime. Each agent gets its own tmux pane and git worktree, tasks dispatch from a Markdown kanban board, and nothing merges until tests pass.

Built in Rust, published on [crates.io](https://crates.io/crates/batty-cli).