### PR TITLE
Add jmux to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.
+- [jmux](https://github.com/jarredkenny/jmux) A tmux-wrapping TUI for running multiple coding agents in parallel, with a persistent sidebar showing every session and what needs attention.
 - [laio](https://laio.sh) A simple, flexbox-inspired, layout & session manager for tmux written in Rust.
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux
 - [moxide](https://github.com/dlurak/moxide) A tmux session manager with a modular config


### PR DESCRIPTION
## Summary

- Adds [jmux](https://github.com/jarredkenny/jmux) to the Tools and session management section (alphabetical order)
- jmux is a tmux-wrapping TUI for running multiple coding agents in parallel — it replaces tmux's status bar with a persistent sidebar showing every session and what needs your attention

🤖 Generated with [Claude Code](https://claude.ai/code)