### PR TITLE
Add lazyclaude to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.
 - [laio](https://laio.sh) A simple, flexbox-inspired, layout & session manager for tmux written in Rust.
+- [lazyclaude](https://github.com/any-context/lazyclaude) A lazygit-inspired TUI for managing multiple Claude Code sessions with live previews, activity tracking, and permission prompts in a tmux popup
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux
 - [moxide](https://github.com/dlurak/moxide) A tmux session manager with a modular config
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management TUI built on tmux


### PR DESCRIPTION
## Summary

Add [lazyclaude](https://github.com/any-context/lazyclaude) to the "Tools and session management" section.

lazyclaude is a lazygit-inspired TUI (written in Go) that manages multiple Claude Code sessions from a single tmux popup. Key features:

- **Session management**: Create, rename, delete, and attach to Claude Code sessions with live output previews
- **Activity tracking**: Real-time status indicators (running, needs input, idle, error, dead) via Claude Code hooks
- **Permission prompts**: Tool approval popups as overlays with one-key approval (no window switching)
- **Fullscreen mode**: Direct keyboard forwarding with vim-like scrollback navigation
- **Multi-agent orchestration**: PM/Worker pattern using isolated git worktrees

Activated via `Ctrl+\` in tmux. Installed via TPM or manually.

- License: MIT
- First commit: March 2026