### PR TITLE
Add opensessions to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [kmux-status](https://github.com/tardunge/kmux-status) - Tmux plugin to render kubernetes context and other indicators on the status-line.
 - [muxile](https://github.com/bjesus/muxile) - View and control your tmux session from your mobile.
 - [nunchux](https://github.com/datamadsen/nunchux) A fuzzy launcher for apps, files, and build tasks with live status, keyboard shortcuts, and task runner integration.
+- [opensessions](https://github.com/Ataraxy-Labs/opensessions) Persistent tmux sidebar for session switching, agent status, git context, and instant jumps across sessions.
 - [tabby](https://github.com/brendandebeasi/tabby) Modern tab manager with a daemon-driven vertical sidebar, window grouping, and full mouse support.
 - [tmux-agent-indicator](https://github.com/accessd/tmux-agent-indicator) Track AI agent state (Claude, Codex, etc.) with pane borders, background colors, window titles, and status bar icons.
 - [tmux-autoreload](https://github.com/b0o/tmux-autoreload) - Watches your tmux configuration file and automatically reloads it on change.


### PR DESCRIPTION
## Summary

Add [opensessions](https://github.com/Ataraxy-Labs/opensessions) to the Plugins section.

opensessions is a persistent tmux sidebar plugin for session switching, agent status, git context, localhost/dev context, and quick jumps back into the right terminal.

- Placed alphabetically in the Plugins section
- Follows the existing list entry format