### PR TITLE
Add `tmux-ai-window-name` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [nunchux](https://github.com/datamadsen/nunchux) A fuzzy launcher for apps, files, and build tasks with live status, keyboard shortcuts, and task runner integration.
 - [tabby](https://github.com/brendandebeasi/tabby) Modern tab manager with a daemon-driven vertical sidebar, window grouping, and full mouse support.
 - [tmux-agent-indicator](https://github.com/accessd/tmux-agent-indicator) Track AI agent state (Claude, Codex, etc.) with pane borders, background colors, window titles, and status bar icons.
+- [tmux-ai-window-name](https://github.com/ndom91/tmux-ai-window-name) Let an LLM automatically update your window names based on metadata about the window (Claude and local LLMs supported)
 - [tmux-autoreload](https://github.com/b0o/tmux-autoreload) - Watches your tmux configuration file and automatically reloads it on change.
 - [tmux-bitwarden](https://github.com/Alkindi42/tmux-bitwarden) Access your Bitwarden login items in a tmux pane.
 - [tmux-browser](https://github.com/ofirgall/tmux-browser) Web browser sessions attached to tmux sessions.


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Added plugin [tmux-ai-window-name](https://github.com/ndom91/tmux-ai-window-name)

> Automatically rename tmux windows using an LLM. The plugin captures the visible content of all panes in a window, sends it to an LLM, and sets a concise kebab-case title describing what you're working on.
> 
> It prioritizes git branch names (from shell prompts and neovim statuslines) to generate context-aware titles like `billing-flag-cleanup` or `ms-teams-channels`.
>
> Supports both a claude mode (`claude -p ..`) and a local LLM mode that can use any OpenAI-compatible API endpoint (llama-cpp, ollama, LM Studio, etc).
> 
> Fork of [ofirgall/tmux-window-name](https://github.com/ofirgall/tmux-window-name) with LLM-powered naming and a classic fallback mode.
> 