### PR TITLE
add dwm.tmux to the plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [back-in-5](https://github.com/hamolicious/back-in-5) display a "Back soon" message for remote collaboration
 - [tmux2html](https://github.com/tweekmonster/tmux2html) :cat2: Render full tmux windows or individual panes as HTML
 - [tmux-better-mouse-mode](https://github.com/NHDaly/tmux-better-mouse-mode) A tmux plugin to better manage and configure the mouse.
+- [dwm.tmux](https://github.com/saysjonathan/dwm.tmux) dwm-inspired tiling pane and window manager for Tmux.
 - [extrakto](https://github.com/laktak/extrakto) tmux clipboard copy and output completions
 - [kmux-status](https://github.com/tardunge/kmux-status) - Tmux plugin to render kubernetes context and other indicators on the status-line.
 - [muxile](https://github.com/bjesus/muxile) - View and control your tmux session from your mobile.


### PR DESCRIPTION
This change adds the dwm.tmux plugin to the list. Currently around 180 stars and some existing users. Supports both TPM and manual installs.