### PR TITLE
Add tmux-ccm to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-autoreload](https://github.com/b0o/tmux-autoreload) - Watches your tmux configuration file and automatically reloads it on change.
 - [tmux-bitwarden](https://github.com/Alkindi42/tmux-bitwarden) Access your Bitwarden login items in a tmux pane.
 - [tmux-browser](https://github.com/ofirgall/tmux-browser) Web browser sessions attached to tmux sessions.
+- [tmux-ccm](https://github.com/yohasebe/tmux-ccm) An attention manager for parallel Claude Code sessions — live state detection (BUSY / IDLE / waiting for permission), popup dashboard, and cross-project messaging.
 - [tmux-cht-sh](https://github.com/kenos1/tmux-cht-sh) Access cheatsheets easily in a popup
 - [tmux-claude-sessions](https://github.com/aomerk/tmux-claude-sessions) Browse and resume Claude AI conversations from a fzf popup
 - [tmux-click-copy](https://github.com/aless3/tmux-click-copy) word/line copy on double/triple click without fixed timeout and without remaining stuck in copy mode


### PR DESCRIPTION
Adds [tmux-ccm](https://github.com/yohasebe/tmux-ccm) — a tmux plugin that manages parallel Claude Code sessions as tmux windows with live state detection (BUSY / IDLE / waiting for permission), a popup dashboard, snapshots, and cross-project messaging.

- Repo: https://github.com/yohasebe/tmux-ccm
- License: MIT
- TPM install: `set -g @plugin 'yohasebe/tmux-ccm'`

Inserted in the Plugins list in alphabetical order, between `tmux-browser` and `tmux-cht-sh`.