### PR TITLE
Add tmux-assistant-resurrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tat](https://github.com/ryandotsmith/tat) Tab completion for tmux sessions
 - [teamocil](https://github.com/remi/teamocil) A simple tool used to automatically create windows and panes in tmux with YAML files
 - [tmex](https://github.com/evnp/tmex) A minimalist tmux layout manager
+- [tmux-assistant-resurrect](https://github.com/timvw/tmux-assistant-resurrect) Persist and restore AI assistant sessions (Claude Code, Codex CLI, etc.) across tmux restarts
 - [tmux-canvas](https://github.com/juancruzfl/tmux-canvas) Create, save, and automate session layouts using executable shell script blueprints.
 - [tmux-cookie-cutter](https://github.com/AranBorkum/tmux-cookie-cutter) A YAML based session builder, configuring windows, panes and environments automatically
 - [tmux-cssh](https://github.com/zinic/tmux-cssh) Tmux with a "ClusterSSH"-like behavior


### PR DESCRIPTION
Adds [tmux-assistant-resurrect](https://github.com/timvw/tmux-assistant-resurrect) to the **Tools and session management** section.

It's a tmux plugin that persists and restores AI coding assistant sessions (Claude Code, Codex CLI, OpenCode) across tmux restarts by hooking into tmux-resurrect to save session IDs and resume them with their original configuration.