### PR TITLE
Add muxbar — macOS menu bar tmux controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [lazyclaude](https://github.com/any-context/lazyclaude) A lazygit-inspired TUI for managing multiple Claude Code sessions with live previews, activity tracking, and permission prompts in a tmux popup
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux
 - [moxide](https://github.com/dlurak/moxide) A tmux session manager with a modular config
+- [muxbar](https://github.com/1989v/muxbar) Menu bar app for tmux session management on macOS — list / attach / kill / live preview, plus a closed-lid mode for in-bag work. MIT.
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management TUI built on tmux
 - [powerline](https://github.com/powerline/powerline) Statusline plugin for vim, and provides statuslines and prompts for several other applications including tmux
 - [tmux-powerline](https://github.com/erikw/tmux-powerline) A hackable statusbar for tmux consisting of dynamic & beautiful looking segments, inspired by vim-powerline, written purely in bash.


### PR DESCRIPTION
Adds [muxbar](https://github.com/1989v/muxbar) — a native macOS menu bar app for tmux session management.

- Lists all tmux sessions in the menu bar with attach / kill / live preview
- Templates (YAML) for new session layouts
- Closed-lid mode for keeping work running with the laptop closed (no external monitor required)
- MIT licensed, Swift/SwiftUI, macOS 13+

Inserted alphabetically under the **Tools and session management** section, between `moxide` and `mynav`.

Note: there is already a different project also named `muxbar` in the Status Bar section (`https://github.com/dlurak/muxbar`, a Rust status bar configurator). This entry is a distinct macOS GUI application at `https://github.com/1989v/muxbar`.