### PR TITLE
Add tmux-palette to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [tmux-mouse-swipe](https://github.com/jaclu/tmux-mouse-swipe) - Switch Window or Session by clicking right mouse button and swiping.
 - [tmux-notify](https://github.com/rickstaa/tmux-notify) A plugin to notify you when processes are finished.
 - [tmux-open-nvim](https://github.com/trevarj/tmux-open-nvim) - A plugin to help open files in a running instance of Neovim. Pairs well with tmux-fingers or tmux-open.
+- [tmux-palette](https://github.com/eduwass/tmux-palette) Raycast-style command palette with fuzzy search, custom commands, themes, and aliases via JSON config.
 - [tmux-fzf-open-files-nvim](https://github.com/Peter-McKinney/tmux-fzf-open-files-nvim) - A plugin that parses pane text for files for selection in fzf to open in neovim.
 - [tmux-thumbs](https://github.com/fcsonline/tmux-thumbs) A lightning fast version of tmux-fingers written in Rust, copy/pasting tmux like vimium/vimperator
 - [tmux-1password](https://github.com/yardnsm/tmux-1password) Access your 1Password login items in a tmux pane.


### PR DESCRIPTION
Adds [tmux-palette](https://github.com/eduwass/tmux-palette) to the Plugins section.

A Raycast-style command palette for tmux: fuzzy search, custom commands/themes/aliases via JSON config in `~/.config/tmux-palette/`, ~30ms cold start. Different angle from the existing `tmux-command-palette` entry (that one is fzf-based; this one has its own ANSI renderer for the Raycast-feel UI, mouse support, and JSON-only user config so users don't have to fork to extend it).