### PR TITLE
feat: modernize GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/awesome_bot.yaml
+++ b/.github/workflows/awesome_bot.yaml
@@ -6,18 +6,31 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.10
-    - name: Checks
+        ruby-version: '3.3'
+        bundler-cache: true
+    - name: Cache Ruby gems
+      uses: actions/cache@v4
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-ruby-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-ruby-
+    - name: Install dependencies
       run: |
         gem install awesome_bot
+    - name: Check links
+      run: |
         awesome_bot --allow-redirect --request-delay 1 README.md


### PR DESCRIPTION
## Summary

Modernize the GitHub Actions CI workflow with the following improvements:

### Changes
- **Upgrade actions/checkout@v2 → v4**: Improved security and performance with newer version
- **Upgrade Ruby 2.6.10 → 3.3**: Use modern Ruby with better performance and features
- **Add explicit permissions block**: Follows security best practices with least-privilege access (contents: read only)
- **Add gem caching**: Uses actions/cache@v4 to cache Ruby gems between runs, speeding up CI
- **Enable bundler-cache**: Added bundler-cache to ruby/setup-ruby action for additional caching
- **Split steps**: Separated dependency installation and link checking into distinct steps for clarity

### Technical Details
- Added  for minimal privilege
- Added gem caching with proper key based on Gemfile.lock hash
- Upgraded all actions to their latest stable versions

This change maintains full backward compatibility while improving CI performance and security posture.