### PR TITLE
Add kubectl-tmux-exec to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.
+- [kubectl-tmux-exec](https://github.com/predatorray/kubectl-tmux-exec) A kubectl plugin that uses tmux to control multiple Kubernetes pods' shells simultaneously, broadcasting commands to all selected containers at once.
 - [laio](https://laio.sh) A simple, flexbox-inspired, layout & session manager for tmux written in Rust.
 - [lazyclaude](https://github.com/any-context/lazyclaude) A lazygit-inspired TUI for managing multiple Claude Code sessions with live previews, activity tracking, and permission prompts in a tmux popup
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux


### PR DESCRIPTION
Hi there!

I'm the author of the [kubectl-tmux-exec](https://github.com/predatorray/kubectl-tmux-exec) plugin, and I'd love to add it to this awesome list.

It's a kubectl plugin that uses tmux to control multiple Kubernetes pods' shells at once, broadcasting commands to all selected containers (like csshX/pssh, but for Kubernetes). I added it under **Tools and session management**, in alphabetical order.

Thanks for maintaining this list!
Wenhao