### PR TITLE
Add tmux-caffeinated to Status Bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [muxbar](https://github.com/dlurak/muxbar) configure the status bar in Rust.
 - [tmux2k](https://github.com/2KAbhishek/tmux2k) Highly customizable tmux status bar framework, providing you with a sleek and informative status bar.
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) Plug and play battery percentage and icon indicator for Tmux.
+- [tmux-caffeinated](https://github.com/eran-rom/tmux-caffeinated) Status line indicator that shows when macOS caffeinate is keeping your Mac awake.
 - [tmux-clima](https://github.com/vascomfnunes/tmux-clima) Displays the current temperature and weather condition using the OpenWeather API.
 - [tmux-code-time](https://github.com/theo64oliver/tmux-code-time) - Tracks time spent in sessions. Displays session duration in your status bar.
 - [tmux-colortag](https://github.com/Determinant/tmux-colortag) a plugin/theme that colors the tmux window tags.


### PR DESCRIPTION
Adds [tmux-caffeinated](https://github.com/eran-rom/tmux-caffeinated), a zero-dependency plugin that shows a status-line indicator while macOS `caffeinate` is running — so you notice when your Mac is being kept awake (e.g. by a long-running AI agent or unattended build) instead of sleeping.

Placed in the Status Bar section in alphabetical order (between `tmux-battery` and `tmux-clima`).