### PR TITLE
Add hivemux to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.
+- [hivemux](https://github.com/Bradical247/hivemux) Tmux-backed orchestrator for parallel AI coding agents (Claude Code, Codex, Gemini, Aider), each in its own git worktree + session. Manage from a CLI, a live TUI, a web/desktop GUI, or a conductor agent over MCP.
 - [laio](https://laio.sh) A simple, flexbox-inspired, layout & session manager for tmux written in Rust.
 - [lazyclaude](https://github.com/any-context/lazyclaude) A lazygit-inspired TUI for managing multiple Claude Code sessions with live previews, activity tracking, and permission prompts in a tmux popup
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux


### PR DESCRIPTION
Adds [hivemux](https://github.com/Bradical247/hivemux): a tmux-backed orchestrator for running parallel AI coding agents, each in its own git worktree + tmux session. Fits alongside ccb and lazyclaude in this section. Manage the fleet from a CLI, a live TUI, a web/desktop GUI, or a conductor agent over MCP. MIT, single binary (npm / Homebrew / AppImage). Placed alphabetically in Tools and session management.