### PR TITLE
Add TermCanvas to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [t](https://github.com/joshmedeski/t-smart-tmux-session-manager) The smart tmux session manager
 - [tat](https://github.com/ryandotsmith/tat) Tab completion for tmux sessions
 - [teamocil](https://github.com/remi/teamocil) A simple tool used to automatically create windows and panes in tmux with YAML files
+- [TermCanvas](https://github.com/lout33/termcanvas) Infinite canvas desktop app that arranges tmux-backed terminal sessions as draggable nodes for steering multiple AI agents
 - [tmex](https://github.com/evnp/tmex) A minimalist tmux layout manager
 - [tmux-canvas](https://github.com/juancruzfl/tmux-canvas) Create, save, and automate session layouts using executable shell script blueprints.
 - [tmux-cookie-cutter](https://github.com/AranBorkum/tmux-cookie-cutter) A YAML based session builder, configuring windows, panes and environments automatically


### PR DESCRIPTION
Adds TermCanvas - an open-source (MIT) desktop app that arranges tmux-backed terminal sessions as draggable nodes on an infinite canvas, for running and steering multiple AI coding agents. It's tmux-backed, so sessions reattach from a plain terminal. Placed alphabetically under Tools and session management.

Repo: https://github.com/lout33/termcanvas