### PR TITLE
Add tmux-claude-status to Status Bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [muxbar](https://github.com/dlurak/muxbar) configure the status bar in Rust.
 - [tmux2k](https://github.com/2KAbhishek/tmux2k) Highly customizable tmux status bar framework, providing you with a sleek and informative status bar.
 - [tmux-battery](https://github.com/tmux-plugins/tmux-battery) Plug and play battery percentage and icon indicator for Tmux.
+- [tmux-claude-status](https://github.com/farnots/tmux-claude-status) Show live Claude Code session status per window: animated badges, waiting durations and global summary.
 - [tmux-clima](https://github.com/vascomfnunes/tmux-clima) Displays the current temperature and weather condition using the OpenWeather API.
 - [tmux-code-time](https://github.com/theo64oliver/tmux-code-time) - Tracks time spent in sessions. Displays session duration in your status bar.
 - [tmux-colortag](https://github.com/Determinant/tmux-colortag) a plugin/theme that colors the tmux window tags.


### PR DESCRIPTION
Adds [tmux-claude-status](https://github.com/farnots/tmux-claude-status): shows the live status of Claude Code sessions per tmux window — animated working badge, waiting-for-input durations, and a global summary for status-right. Inserted in alphabetical order in the Status Bar section.