### PR TITLE
Add tmux-agent-view to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [opensessions](https://github.com/Ataraxy-Labs/opensessions) Persistent tmux sidebar for session switching, agent status, git context, and instant jumps across sessions.
 - [tabby](https://github.com/brendandebeasi/tabby) Modern tab manager with a daemon-driven vertical sidebar, window grouping, and full mouse support.
 - [tmux-agent-indicator](https://github.com/accessd/tmux-agent-indicator) Track AI agent state (Claude, Codex, etc.) with pane borders, background colors, window titles, and status bar icons.
+- [tmux-agent-view](https://github.com/luopeixiang/tmux-agent-view) Claude Code-style agent view — jump to any AI agent pane (Claude Code, Codex, aider) across sessions from a popup picker, grouped by live state, with screen preview. No hooks or daemon.
 - [tmux-ai-window-name](https://github.com/ndom91/tmux-ai-window-name) Let an LLM automatically update your window names based on metadata about the window (Claude and local LLMs supported)
 - [tmux-autoreload](https://github.com/b0o/tmux-autoreload) - Watches your tmux configuration file and automatically reloads it on change.
 - [tmux-bitwarden](https://github.com/Alkindi42/tmux-bitwarden) Access your Bitwarden login items in a tmux pane.


### PR DESCRIPTION
Adds [tmux-agent-view](https://github.com/luopeixiang/tmux-agent-view) to the Plugins section (alphabetical order, next to the other AI-agent plugins).

It's a popup picker (`prefix + a`) that lists every AI agent pane (Claude Code, Codex, OpenCode, aider) across all tmux sessions — Claude Code-style agent view, grouped by live state detected from screen content, needs-input first, with a live preview, git branch, and conversation topic. Jumping is plain `switch-client`; no hooks, no daemon, no state files. Single bash script (bash 3.2 compatible), requires tmux ≥ 3.2 and fzf. MIT licensed.