### PR TITLE
Add any-console to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 
 ## <a name="tools"></a>Tools and session management
 
+- [any-console](https://github.com/kt0319/any-console) A mobile-first web UI to attach and manage tmux sessions from any browser, with Git operations and AI coding agents, served over Tailscale
 - [automux](https://github.com/sriramkandukuri/automux) Wrappers to tmux commands, useful for tmux based automation
 - [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files


### PR DESCRIPTION
Adds [any-console](https://github.com/kt0319/any-console) to the **Tools and session management** section (placed alphabetically at the top).

any-console runs on tmux for persistent sessions and lets you attach, create, detach, and manage those sessions from any browser (phone or desktop), alongside Git operations and AI coding agents, served over Tailscale. MIT licensed.

Matches the existing entry format and alphabetical ordering.