### PR TITLE
Add pointflow to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux
 - [moxide](https://github.com/dlurak/moxide) A tmux session manager with a modular config
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management TUI built on tmux
+- [pointflow](https://github.com/supreeth-Finsamudra/pointflow) View and type into any tmux pane from a phone browser — full-color xterm.js with scrollback, byte-exact send-keys, QR token pairing
 - [powerline](https://github.com/powerline/powerline) Statusline plugin for vim, and provides statuslines and prompts for several other applications including tmux
 - [tmux-powerline](https://github.com/erikw/tmux-powerline) A hackable statusbar for tmux consisting of dynamic & beautiful looking segments, inspired by vim-powerline, written purely in bash.
 - [sesh](https://github.com/joshmedeski/sesh) Smart session manager for the terminal


### PR DESCRIPTION
Adds [pointflow](https://github.com/supreeth-Finsamudra/pointflow) — a local Rust agent that streams tmux panes to a phone browser (xterm.js, full scrollback/colors) and types back into them via byte-exact `send-keys`. Panes can be viewed/driven without being the focused window; connections are token-paired via QR.

Placed alphabetically in *Tools and session management*, matching the existing line format.

Disclosure: I'm one of the authors of pointflow. Happy to adjust wording or placement.