### PR TITLE
Add focusd to 'Tools and session management' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
+- [focusd](https://github.com/SiiahK/focusd) A local-first focus and habit engine with a live tmux status bar timer and a post-commit git hook that auto-updates your coding habits and streak with zero manual check-ins
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.
 - [laio](https://laio.sh) A simple, flexbox-inspired, layout & session manager for tmux written in Rust.
 - [lazyclaude](https://github.com/any-context/lazyclaude) A lazygit-inspired TUI for managing multiple Claude Code sessions with live previews, activity tracking, and permission prompts in a tmux popup


### PR DESCRIPTION
## What

Adds **focusd** to the *Tools and session management* section, in alphabetical order (between `dmux` and `harpoon`), following the list's entry format.

[focusd](https://github.com/SiiahK/focusd) is a local-first focus and habit engine for terminal workflows:

- live focus timer segment for the tmux status bar (hard 250ms budget; prints nothing when idle, so the bar stays clean)
- a keybind script to log focus blocks from tmux
- a post-commit git hook that updates your coding habits and streak automatically — zero manual check-ins
- a Neovim plugin with passive telemetry over a unix socket
- single static Go binary, SQLite storage, MIT licensed, no cloud, no account, no data leaves the machine

## Checklist

- [x] Entry follows the list format: `- [name](url) Description`
- [x] Inserted in alphabetical order
- [x] Project is open source (MIT), documented (README with install/usage), and the link works
- [x] Disclosure: I am the author of the project