### PR TITLE
Add AgentBox to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 
 ## <a name="tools"></a>Tools and session management
 
+- [AgentBox](https://github.com/madarco/agentbox) Run multiple coding agents in parallel, each in a sandboxed VM launched in detachable tmux sessions
 - [automux](https://github.com/sriramkandukuri/automux) Wrappers to tmux commands, useful for tmux based automation
 - [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files


### PR DESCRIPTION
Adds [AgentBox](https://github.com/madarco/agentbox) to **Tools and session management**.

AgentBox launches each coding agent in its own sandboxed VM inside a detachable tmux session — parallel agent sessions with per-box isolation. Local Docker, self-hosted, or cloud. MIT.