### PR TITLE
Add native-team to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux
 - [moxide](https://github.com/dlurak/moxide) A tmux session manager with a modular config
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management TUI built on tmux
+- [native-team](https://github.com/JaySNL/native-team) A Claude lead delegates scoped tasks to local qwen grunts in adjacent tmux panes, coordinated by a plain directory bus; every grunt citation is re-read and verified byte-for-byte.
 - [powerline](https://github.com/powerline/powerline) Statusline plugin for vim, and provides statuslines and prompts for several other applications including tmux
 - [tmux-powerline](https://github.com/erikw/tmux-powerline) A hackable statusbar for tmux consisting of dynamic & beautiful looking segments, inspired by vim-powerline, written purely in bash.
 - [sesh](https://github.com/joshmedeski/sesh) Smart session manager for the terminal


### PR DESCRIPTION
native-team runs a Claude lead and interactive qwen grunts in adjacent tmux panes (each grunt in its own git worktree), coordinated by a plain directory bus. It belongs under Tools and session management alongside entries like ccb and lazyclaude. A distinguishing feature: every file:line a grunt cites is re-read and verified byte-for-byte, failing closed. Repo: https://github.com/JaySNL/native-team  (MIT, stdlib-only Python.)