### PR TITLE
Add Mobile SSH to Tools and session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 - [laio](https://laio.sh) A simple, flexbox-inspired, layout & session manager for tmux written in Rust.
 - [lazyclaude](https://github.com/any-context/lazyclaude) A lazygit-inspired TUI for managing multiple Claude Code sessions with live previews, activity tracking, and permission prompts in a tmux popup
 - [libtmux](https://github.com/tmux-python/libtmux) Python API for tmux
+- [Mobile SSH](https://mobile-ssh.github.io/) A mobile tmux session manager for Android and iOS to list, attach, rename, create, split, zoom, and kill tmux sessions, windows, and panes across multiple servers over SSH, with auto-attach on reconnect
 - [moxide](https://github.com/dlurak/moxide) A tmux session manager with a modular config
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management TUI built on tmux
 - [powerline](https://github.com/powerline/powerline) Statusline plugin for vim, and provides statuslines and prompts for several other applications including tmux


### PR DESCRIPTION
Adds **Mobile SSH** to the Tools and session management section.

Mobile SSH is a mobile app (Android + iOS) with a first-class tmux session manager: list, attach, rename, create, split, zoom, and kill tmux sessions, windows, and panes across multiple servers over SSH, with a bell flag for sessions awaiting input and auto-attach on reconnect. Website: https://mobile-ssh.github.io/

- Inserted alphabetically between `libtmux` and `moxide`.
- Matches the section's `- [name](url) Description` format.
- There's a mobile precedent in the list already (`muxile` — control tmux from your phone).

Thanks for maintaining the list!