### PR TITLE
Add grok-hud — tmux status pane for Grok Build sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ List of helpful tmux links for various tutorials, plugins, and configuration set
 
 - [automux](https://github.com/sriramkandukuri/automux) Wrappers to tmux commands, useful for tmux based automation
 - [ccb](https://github.com/bfly123/claude_code_bridge) A CLI tool to orchestrate multiple LLMs (Claude, Gemini, etc.) in tmux panes with cross-agent interaction
+- [grok-hud](https://github.com/Rennlabs/grok-hud) Persistent tmux status pane for Grok Build / Claude harness sessions (`grok-with-hud` launcher). Part of [grokpack](https://github.com/Rennlabs/grokpack).
 - [disconnected](https://github.com/austinwilcox/disconnected) A session manager written in Deno with json as the config files
 - [dmux](https://github.com/zdcthomas/dmux) Configurable tmux workspace manager written in Rust
 - [harpoon](https://github.com/Chaitanyabsprip/tmux-harpoon) A tool to bookmark sessions and jump between them in a flash. Like ThePrimeagen/harpoon, but for tmux.


### PR DESCRIPTION
## Summary
Adds [grok-hud](https://github.com/Rennlabs/grok-hud), a fixed-layout tmux status pane for Grok Build / Claude harness sessions, plus `grok-with-hud` launcher.

Part of the [grokpack](https://github.com/Rennlabs/grokpack) suite (observe / drive / display).

- MIT · unofficial · not affiliated with xAI
- Read-only status (git, session, modes, verifier)